### PR TITLE
ensure fsc runs when `Tensor.device != "cpu"`

### DIFF
--- a/src/torch_fourier_shell_correlation/fsc.py
+++ b/src/torch_fourier_shell_correlation/fsc.py
@@ -37,13 +37,14 @@ def fsc(
         a, b, frequencies = (torch.flatten(arg) for arg in [a, b, frequency_grid])
 
     # define frequency bins
-    bin_centers = torch.fft.rfftfreq(image_shape[0])
+    bin_centers = torch.fft.rfftfreq(image_shape[0], device=a.device)
     df = 1 / image_shape[0]
 
     # setup to split data at midpoint between frequency bin centers
-    bin_centers = torch.cat([bin_centers, torch.as_tensor([0.5 + df])])
+    bin_centers = torch.cat([bin_centers, torch.as_tensor([0.5 + df], device=a.device)])
     bin_centers = bin_centers.unfold(dimension=0, size=2, step=1)  # (n_shells, 2)
     split_points = einops.reduce(bin_centers, 'shells high_low -> shells', reduction='mean')
+    
 
     # find indices of all components in each shell
     sorted_frequencies, sort_idx = torch.sort(frequencies, descending=False)

--- a/src/torch_fourier_shell_correlation/fsc.py
+++ b/src/torch_fourier_shell_correlation/fsc.py
@@ -49,7 +49,7 @@ def fsc(
     # find indices of all components in each shell
     sorted_frequencies, sort_idx = torch.sort(frequencies, descending=False)
     split_idx = torch.searchsorted(sorted_frequencies, split_points)
-    shell_idx = torch.tensor_split(sort_idx, split_idx)[:-1]
+    shell_idx = torch.tensor_split(sort_idx, split_idx.cpu())[:-1]
 
     # calculate normalised cross correlation in each shell
     fsc = [


### PR DESCRIPTION
I've been using this library a little and found that it was throwing "tensors on GPU and CPU" errors when running on the GPU. It should be fixed now.

Other changes I'm thinking of making:
1) I also found the lack of batching ability a little bit annoying.
2) Split the def fsc into two extra functions, as it does a little too much. One that does the the rfft, one that does the frequencies. That way it's easier to pull out parts you need (i.e. I don't need to fft, and need to ifft to use the function as is).
